### PR TITLE
fix: extended Message, Enum

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -135,6 +135,15 @@ func constructMessage(m *protogen.Message) *Message {
 	for _, f := range m.Fields {
 		message.Fields = append(message.Fields, constructField(message, f))
 	}
+	for _, m := range m.Messages {
+		message.Messages = append(message.Messages, constructMessage(m))
+	}
+	for _, e := range m.Enums {
+		message.Enums = append(message.Enums, constructEnum(e))
+	}
+	for _, o := range m.Oneofs {
+		message.Oneofs = append(message.Oneofs, constructOneof(message, o))
+	}
 	return message
 }
 
@@ -149,6 +158,22 @@ func constructField(parent *Message, f *protogen.Field) *Field {
 		field.Options = &FieldOptions{FieldOptions: o}
 	}
 	return field
+}
+
+func constructOneof(parent *Message, o *protogen.Oneof) *Oneof {
+	oneof := &Oneof{
+		FullName: o.Desc.FullName(),
+		Desc:     o.Desc,
+		Parent:   parent,
+		Comments: protogen.CommentSet{},
+	}
+	if o := o.Desc.Options().(*descriptorpb.OneofOptions); o != nil {
+		oneof.Options = &OneofOptions{OneofOptions: o}
+	}
+	for _, f := range o.Fields {
+		oneof.Fields = append(oneof.Fields, constructField(oneof.Parent, f))
+	}
+	return oneof
 }
 
 func constructEnum(e *protogen.Enum) *Enum {

--- a/prototype.go
+++ b/prototype.go
@@ -110,7 +110,7 @@ type Oneof struct {
 
 // OneofOptions represents the options for a protobuf oneof field.
 type OneofOptions struct {
-	descriptorpb.OneofOptions // OneofOptions is the embedded protobuf oneof options.
+	*descriptorpb.OneofOptions // OneofOptions is the embedded protobuf oneof options.
 }
 
 // Field represents a field in a protobuf message.


### PR DESCRIPTION
This pull request enhances the handling of Protobuf `oneof` constructs by introducing new functionality for constructing and representing `oneof` fields in the codebase. The changes primarily focus on adding support for nested `oneof` fields and improving the data structure to accommodate this functionality.

### Enhancements to Protobuf `oneof` handling:

* **Support for nested `oneof` fields in message construction**:
  - Updated the `constructMessage` function in `plugin.go` to iterate over `oneof` fields in a Protobuf message and construct them using the new `constructOneof` function. (`[plugin.goR138-R146](diffhunk://#diff-8c9bf6ac6a298e3c093386b6f36e0cade8724ef38e50f80c7ecf19cd6e562471R138-R146)`)

* **New `constructOneof` function**:
  - Added a new function `constructOneof` in `plugin.go` to handle the creation of `Oneof` objects, including setting properties like `FullName`, `Desc`, `Parent`, and `Options`. It also constructs fields within the `oneof`. (`[plugin.goR163-R178](diffhunk://#diff-8c9bf6ac6a298e3c093386b6f36e0cade8724ef38e50f80c7ecf19cd6e562471R163-R178)`)

### Changes to the `OneofOptions` structure:

* **Refactor of `OneofOptions` type**:
  - Modified the `OneofOptions` struct in `prototype.go` to embed a pointer to `descriptorpb.OneofOptions` instead of the value type, allowing for better handling of optional `oneof` options. (`[prototype.goL113-R113](diffhunk://#diff-4cf087454056a2fb0447b54bbf91dfcaa7fef34163905eec13284f8fb614e6adL113-R113)`)